### PR TITLE
feat: use `git http-backend` to serve smart http server

### DIFF
--- a/mirror.go
+++ b/mirror.go
@@ -28,18 +28,12 @@ func mirror(cfg config, r repo) (string, error) {
 		cmd := exec.Command("git", "clone", "--mirror", r.Origin, repoPath)
 		cmd.Dir = parent
 		out, err := cmd.CombinedOutput()
-		outStr = string(out)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to clone %s, %s", r.Origin, err)
 		}
 		return string(out), err
 	} else {
 		return "", fmt.Errorf("failed to stat %s, %s", repoPath, err)
-	}
-	cmd := exec.Command("git", "update-server-info")
-	cmd.Dir = repoPath
-	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("failed to update-server-info for %s, %s", repoPath, err)
 	}
 	return outStr, nil
 }


### PR DESCRIPTION
Dumb HTTP server does provide an option for shallow clones, so we can switch git mirror to https://git-scm.com/docs/git-http-backend and make it use the smart protocol